### PR TITLE
Add xz.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
-# base-plan-skeleton
-Template for all new Chef Base Plans to simplify creation of repositories.
+[![Build Status](https://dev.azure.com/chefcorp-partnerengineering/Chef%20Base%20Plans/_apis/build/status/chef-base-plans.xz?branchName=master)](https://dev.azure.com/chefcorp-partnerengineering/Chef%20Base%20Plans/_build/latest?definitionId=143&branchName=master)
+
+# xz
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/attributes.yml
+++ b/attributes.yml
@@ -1,0 +1,1 @@
+plan_name : "xz"

--- a/controls/xz_test.rb
+++ b/controls/xz_test.rb
@@ -1,0 +1,30 @@
+title 'Tests to confirm xz works as expected'
+
+plan_name = input('plan_name', value: 'xz')
+plan_ident = "#{ENV['HAB_ORIGIN']}/#{plan_name}"
+hab_path = input('hab_path', value: 'hab')
+
+control 'core-plans-xz' do
+  impact 1.0
+  title 'Ensure xz works'
+  desc '
+  For xz we check that the version is correctly returned e.g.
+
+    $ xz --version
+    xz (XZ Utils) 5.2.5
+    liblzma 5.2.5
+  '
+  xz_pkg_ident = command("#{hab_path} pkg path #{plan_ident}")
+  describe xz_pkg_ident do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not be_empty }
+  end
+  xz_pkg_ident = xz_pkg_ident.stdout.strip
+
+  describe command("#{xz_pkg_ident}/bin/xz --version") do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not be_empty }
+    its('stdout') { should match /xz \(XZ Utils\)\s+#{xz_pkg_ident.split('/')[5]}/ }
+    its('stderr') { should be_empty }
+  end
+end

--- a/inspec.yml
+++ b/inspec.yml
@@ -1,7 +1,7 @@
-name: {{plan_name}}
-title: Habitat Core Plan {{plan_name}}
+name: xz
+title: Habitat Core Plan xz
 maintainer: humans@habitat.sh
-summary: InSpec controls for testing Habitat Core Plan {{plan_name}}
+summary: InSpec controls for testing Habitat Core Plan xz
 copyright: humans@habitat.sh
 copyright_email: humans@habitat.sh
 version: 0.1.0

--- a/plan.ps1
+++ b/plan.ps1
@@ -1,0 +1,18 @@
+$pkg_name="xz"
+$pkg_origin="core"
+$pkg_version="5.2.4"
+$pkg_description="XZ Utils is free general-purpose data compression software with a high compression ratio. XZ Utils were written for POSIX-like systems, but also work on some not-so-POSIX systems. XZ Utils are the successor to LZMA Utils."
+$pkg_upstream_url="http://tukaani.org/xz/"
+$pkg_license=@("GPL-2.0-or-later", "LGPL-2.0-or-later")
+$pkg_source="https://tukaani.org/${pkg_name}/${pkg_name}-${pkg_version}-windows.zip"
+$pkg_shasum="9a5163623f435b6fa0844b6b884babd6bf4f8d876ae2d8134deeb296afd49c61"
+$pkg_bin_dirs=@("bin")
+$pkg_include_dirs=@("include")
+$pkg_lib_dirs=@("lib")
+
+function Invoke-Install {
+    Copy-Item "$HAB_CACHE_SRC_PATH\$pkg_name-$pkg_version\bin_x86-64\*.dll" "$pkg_prefix\bin\" -Force
+    Copy-Item "$HAB_CACHE_SRC_PATH\$pkg_name-$pkg_version\bin_x86-64\*.exe" "$pkg_prefix\bin\" -Force
+    Copy-Item "$HAB_CACHE_SRC_PATH\$pkg_name-$pkg_version\bin_x86-64\*.a" "$pkg_prefix\lib\" -Force
+    Copy-Item "$HAB_CACHE_SRC_PATH\$pkg_name-$pkg_version\include\*" "$pkg_prefix\include\" -Recurse -Force
+}

--- a/plan.sh
+++ b/plan.sh
@@ -1,0 +1,51 @@
+pkg_name=xz
+_distname="$pkg_name"
+pkg_origin=core
+pkg_version=5.2.4
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_description="\
+XZ Utils is free general-purpose data compression software with a high \
+compression ratio. XZ Utils were written for POSIX-like systems, but also \
+work on some not-so-POSIX systems. XZ Utils are the successor to LZMA Utils.\
+"
+pkg_upstream_url="http://tukaani.org/xz/"
+pkg_license=('GPL-2.0-or-later' 'LGPL-2.0-or-later')
+pkg_source="http://tukaani.org/${_distname}/${_distname}-${pkg_version}.tar.gz"
+pkg_shasum="b512f3b726d3b37b6dc4c8570e137b9311e7552e8ccbab4d39d47ce5f4177145"
+pkg_dirname="${_distname}-${pkg_version}"
+pkg_deps=(
+  core/glibc
+)
+pkg_build_deps=(
+  core/coreutils
+  core/diffutils
+  core/patch
+  core/make
+  core/gcc
+  core/sed
+)
+pkg_bin_dirs=(bin)
+pkg_include_dirs=(include)
+pkg_lib_dirs=(lib)
+pkg_pconfig_dirs=(lib/pkgconfig)
+
+do_check() {
+  make check
+}
+
+
+# ----------------------------------------------------------------------------
+# **NOTICE:** What follows are implementation details required for building a
+# first-pass, "stage1" toolchain and environment. It is only used when running
+# in a "stage1" Studio and can be safely ignored by almost everyone. Having
+# said that, it performs a vital bootstrapping process and cannot be removed or
+# significantly altered. Thank you!
+# ----------------------------------------------------------------------------
+if [[ "$STUDIO_TYPE" = "stage1" ]]; then
+  pkg_build_deps=(
+    core/gcc
+    core/coreutils
+    core/sed
+    core/diffutils
+  )
+fi

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -1,0 +1,5 @@
+expected_version="$(echo "${TEST_PKG_IDENT}" | cut -d/ -f3)"
+@test "xz version matches ${expected_version}" {
+  actual_version="$(hab pkg exec "${TEST_PKG_IDENT}" xz --version | awk '/XZ Utils/{print $4}')"
+  diff <( echo "$actual_version" ) <( echo "${expected_version}" )
+}

--- a/tests/test.pester.ps1
+++ b/tests/test.pester.ps1
@@ -1,0 +1,14 @@
+param (
+    [Parameter()]
+    [string]$PackageIdentifier = $(throw "Fully qualified package identifier must be given as a parameter.")
+)
+
+$PackageVersion = $PackageIdentifier.split('/')[2]
+Describe "core/xz" {
+    Context "xz" {
+        $OutputVariable = ((hab pkg exec $PackageIdentifier xz --version)[0] | Out-String).Trim()
+        It "returns --version that matches the plan" {
+            "$OutputVariable"  | Should -BeExactly "xz (XZ Utils) $PackageVersion"
+        }
+    }
+}

--- a/tests/test.ps1
+++ b/tests/test.ps1
@@ -1,0 +1,22 @@
+# Ensure package ident has been passed
+param (
+    [Parameter()]
+    [string]$PackageIdentifier = $(throw "Usage: test.ps1 [test_pgk_ident] e.g. test.ps1 core/7zip/16.04/20190513101258")
+)
+
+# Ensure Pester is installed
+if (-Not (Get-Module -ListAvailable -Name Pester)) {
+    hab pkg install core/pester
+    Import-Module "$(hab pkg path core/pester)\module\pester.psd1"
+}
+
+# Install the package
+hab pkg install $PackageIdentifier
+
+# Test the package
+$__dir=(Get-Item $PSScriptRoot)
+$test_result = Invoke-Pester -PassThru -Script @{
+    Path = "$__dir/test.pester.ps1";
+    Parameters = @{PackageIdentifier=$PackageIdentifier}
+}
+Exit $test_result.FailedCount

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+set -euo pipefail
+
+#/ Usage: test.sh <pkg_ident>
+#/
+#/ Example: test.sh core/opa/0.11.0/20190531065119
+#/
+
+TESTDIR="$(dirname "${0}")"
+
+if [[ -z "${1:-}" ]]; then
+  grep '^#/' < "${0}" | cut -c4-
+  exit 1
+fi
+
+TEST_PKG_IDENT="$1"
+
+hab pkg install core/bats --binlink
+hab pkg install "${TEST_PKG_IDENT}"
+
+export TEST_PKG_IDENT
+bats "${TESTDIR}/test.bats"


### PR DESCRIPTION
Migration from core plans:

```
Profile: Habitat Core Plan xz (xz)
Version: 0.1.0
Target:  docker://dfb232a625b47221a423bd9554a681a00c66623549fb46cc8dcd770ab72ff3f6

  ✔  core-plans-xz: Ensure xz works
     ✔  Command: `hab pkg path habskp/xz` exit_status is expected to eq 0
     ✔  Command: `hab pkg path habskp/xz` stdout is expected not to be empty
     ✔  Command: `/hab/pkgs/habskp/xz/5.2.4/20200610090953/bin/xz --version` exit_status is expected to eq 0
     ✔  Command: `/hab/pkgs/habskp/xz/5.2.4/20200610090953/bin/xz --version` stdout is expected not to be empty
     ✔  Command: `/hab/pkgs/habskp/xz/5.2.4/20200610090953/bin/xz --version` stdout is expected to match /xz \(XZ Utils\)\s+5.2.4/
     ✔  Command: `/hab/pkgs/habskp/xz/5.2.4/20200610090953/bin/xz --version` stderr is expected to be empty
```

﻿Signed-off-by: Stuart Paterson <spaterson@chef.io>
